### PR TITLE
perf: speed up services status

### DIFF
--- a/toolbox/commands/services.py
+++ b/toolbox/commands/services.py
@@ -15,13 +15,14 @@ from toolbox.utils.deployment.deployment import (
     load_deployments_config,
     resolve_main_compose_path,
 )
+from toolbox.utils.deployment.models import StackStatus
 from toolbox.utils.deployment.network import (
     ensure_stack_network,
     ensure_swarm_ready,
 )
 from toolbox.utils.deployment.service import get_stack_logs
 from toolbox.utils.deployment.stack import MAIN_STACK_NAME, deploy_stack, remove_stack
-from toolbox.utils.deployment.stats import get_stack_status
+from toolbox.utils.deployment.stats import get_all_service_stats, get_existing_stacks, get_stack_status
 
 app = typer.Typer(no_args_is_help=True, help="Manage CTF task services")
 
@@ -81,10 +82,19 @@ def status(
 
     for target_name in sorted(by_target):
         docker = create_docker_client()
+        existing_stacks = get_existing_stacks(docker)
+        status_stack_names = {deployment.stack_name for deployment in by_target[target_name]}
+        if not task:
+            status_stack_names.add(MAIN_STACK_NAME)
+        service_stats = (
+            get_all_service_stats(docker)
+            if existing_stacks is not None and not status_stack_names.isdisjoint(existing_stacks)
+            else {}
+        )
         if not task:
             main_compose = resolve_main_compose_path(context.obj["config_directory"], target_name, None)
             expected_services = load_compose_service_specs(main_compose)
-            stack_status = get_stack_status(docker, MAIN_STACK_NAME, expected_services)
+            stack_status = _stack_status(docker, MAIN_STACK_NAME, expected_services, existing_stacks, service_stats)
             table.add_row(
                 MAIN_STACK_NAME,
                 target_name,
@@ -97,7 +107,13 @@ def status(
             )
         for deployment in by_target[target_name]:
             expected_services = load_compose_service_specs(deployment.compose_file)
-            stack_status = get_stack_status(docker, deployment.stack_name, expected_services)
+            stack_status = _stack_status(
+                docker,
+                deployment.stack_name,
+                expected_services,
+                existing_stacks,
+                service_stats,
+            )
             table.add_row(
                 deployment.task_id,
                 target_name,
@@ -110,6 +126,12 @@ def status(
             )
 
     rich.print(table)
+
+
+def _stack_status(docker, stack_name, expected_services, existing_stacks, service_stats) -> StackStatus:
+    if existing_stacks is None:
+        return StackStatus("swarm inactive", "docker swarm is not initialized on this target")
+    return get_stack_status(docker, stack_name, expected_services, existing_stacks, service_stats)
 
 
 @app.command("up")

--- a/toolbox/utils/deployment/stats.py
+++ b/toolbox/utils/deployment/stats.py
@@ -2,7 +2,9 @@ from python_on_whales import DockerClient
 from python_on_whales.exceptions import DockerException, NoSuchService, NotASwarmManager
 
 from .models import ComposeServiceSpec, StackStatus
-from .service import get_service_container_stats, inspect_stack_service, service_replicas
+from .service import inspect_stack_service, service_replicas
+
+type ServiceStats = dict[str, tuple[float, int, int, int]]
 
 
 def compute_overall_state(states: list[str]) -> str:
@@ -18,11 +20,18 @@ def compute_overall_state(states: list[str]) -> str:
     return "partial"
 
 
-def get_stack_status(docker: DockerClient, stack_name: str, expected_services: list[ComposeServiceSpec]) -> StackStatus:
-    try:
-        existing_stacks = {stack.name for stack in docker.stack.list()}
-    except NotASwarmManager:
-        return StackStatus("swarm inactive", "docker swarm is not initialized on this target")
+def get_stack_status(
+    docker: DockerClient,
+    stack_name: str,
+    expected_services: list[ComposeServiceSpec],
+    existing_stacks: set[str] | None = None,
+    service_stats: ServiceStats | None = None,
+) -> StackStatus:
+    if existing_stacks is None:
+        try:
+            existing_stacks = {stack.name for stack in docker.stack.list()}
+        except NotASwarmManager:
+            return StackStatus("swarm inactive", "docker swarm is not initialized on this target")
     if stack_name not in existing_stacks:
         return StackStatus("not deployed", "stack missing")
 
@@ -42,11 +51,11 @@ def get_stack_status(docker: DockerClient, stack_name: str, expected_services: l
         state = summarize_service_state(service)
         service_states.append((service_spec.name, state))
 
-        for stats in get_service_container_stats(docker, service.spec.name):
-            cpu_total += float(stats.cpu_percentage or 0)
-            mem_total += int(stats.memory_used or 0)
-            network_bytes_received += int(stats.net_download or 0)
-            network_bytes_sent += int(stats.net_upload or 0)
+        cpu, memory, network_rx, network_tx = (service_stats or {}).get(service.spec.name, (0.0, 0, 0, 0))
+        cpu_total += cpu
+        mem_total += memory
+        network_bytes_received += network_rx
+        network_bytes_sent += network_tx
 
     states = [state for _, state in service_states]
     details = ", ".join(f"{name}: {state}" for name, state in service_states)
@@ -77,6 +86,65 @@ def summarize_service_state(service) -> str:
     return compute_overall_state([t.status.state for t in tasks if t.status])
 
 
+def get_existing_stacks(docker: DockerClient) -> set[str] | None:
+    try:
+        return {stack.name for stack in docker.stack.list()}
+    except NotASwarmManager:
+        return None
+
+
+def get_all_service_stats(docker: DockerClient) -> ServiceStats:
+    containers = docker.container.list()
+    if not containers:
+        return {}
+
+    container_services: dict[str, str] = {}
+    for container in containers:
+        service_name = _container_label(container, "com.docker.swarm.service.name")
+        if not service_name:
+            continue
+        container_services[container.id] = service_name
+        container_services[container.id[:12]] = service_name
+    if not container_services:
+        return {}
+
+    service_stats: ServiceStats = {}
+    try:
+        stats_list = docker.container.stats(containers)
+    except DockerException:
+        return {}
+
+    for stats in stats_list:
+        container_id = _stats_container_id(stats)
+        if not container_id:
+            continue
+        service_name = container_services.get(container_id)
+        if not service_name:
+            continue
+
+        cpu, memory, network_rx, network_tx = service_stats.get(service_name, (0.0, 0, 0, 0))
+        service_stats[service_name] = (
+            cpu + float(stats.cpu_percentage or 0),
+            memory + int(stats.memory_used or 0),
+            network_rx + int(stats.net_download or 0),
+            network_tx + int(stats.net_upload or 0),
+        )
+
+    return service_stats
+
+
+def _container_label(container, label: str) -> str | None:
+    config = getattr(container, "config", None)
+    labels = getattr(config, "labels", None) or getattr(container, "labels", None) or {}
+    if isinstance(config, dict):
+        labels = config.get("Labels") or config.get("labels") or labels
+    return labels.get(label)
+
+
+def _stats_container_id(stats) -> str | None:
+    return getattr(stats, "container_id", None) or getattr(stats, "id", None) or getattr(stats, "container", None)
+
+
 def format_bytes(value: int) -> str:
     units = ["B", "KB", "MB", "GB", "TB"]
     size = float(value)
@@ -84,3 +152,4 @@ def format_bytes(value: int) -> str:
         if size < 1024 or unit == units[-1]:
             return f"{size:.1f}{unit}"
         size /= 1024
+    return f"{size:.1f}B"


### PR DESCRIPTION
Avoid duplicate calls to docker for status making the `toolbox services ps` command way more performant.